### PR TITLE
Prepare ktx tool for future plugin support

### DIFF
--- a/tools/ktx/command.cpp
+++ b/tools/ktx/command.cpp
@@ -35,7 +35,7 @@ void Command::error(const char* pFmt, ...) {
     std::cerr << "\n";
 }
 
-void Command::processCommandLine(int argc, _TCHAR* argv[], StdinUse stdinStat, OutfilePos outfilePos, int startIndex) {
+void Command::processCommandLine(int argc, _TCHAR* argv[], StdinUse stdinStat, OutfilePos outfilePos) {
     uint32_t i;
     size_t slash, dot;
 
@@ -50,7 +50,7 @@ void Command::processCommandLine(int argc, _TCHAR* argv[], StdinUse stdinStat, O
     if (dot != _tstring::npos)
         processName.erase(dot, _tstring::npos); // Remove extension.
 
-    argparser parser(argc, argv, startIndex);
+    argparser parser(argc, argv);
     processOptions(parser);
 
     i = parser.optind;

--- a/tools/ktx/command_info.cpp
+++ b/tools/ktx/command_info.cpp
@@ -49,10 +49,6 @@ private:
     int printInfo(const _tstring& infile);
 };
 
-std::unique_ptr<Command> createCommandInfo() {
-    return std::make_unique<CommandInfo>();
-}
-
 // -------------------------------------------------------------------------------------------------
 
 void CommandInfo::initializeOptions() {
@@ -96,7 +92,7 @@ void CommandInfo::processPositional(const std::vector<_tstring>& infiles, const 
 
 int CommandInfo::main(int argc, _TCHAR* argv[]) {
     initializeOptions();
-    processCommandLine(argc, argv, StdinUse::eAllowStdin, OutfilePos::eNone, 2);
+    processCommandLine(argc, argv, StdinUse::eAllowStdin, OutfilePos::eNone);
     processPositional(genericOptions.infiles, genericOptions.outfile);
 
     // std::cout << "processName: " << processName << std::endl;
@@ -154,3 +150,5 @@ int CommandInfo::printInfo(const _tstring& infile) {
 }
 
 } // namespace ktx
+
+KTX_COMMAND_ENTRY_POINT(ktxInfo, ktx::CommandInfo)

--- a/tools/ktx/command_validate.cpp
+++ b/tools/ktx/command_validate.cpp
@@ -39,7 +39,7 @@ public:
         std::cout << "Hello, Validate" << std::endl;
 
         initializeOptions();
-        processCommandLine(argc, argv, StdinUse::eAllowStdin, OutfilePos::eNone, 2);
+        processCommandLine(argc, argv, StdinUse::eAllowStdin, OutfilePos::eNone);
         processPositional(genericOptions.infiles, genericOptions.outfile);
 
         return EXIT_SUCCESS;
@@ -54,3 +54,5 @@ std::unique_ptr<Command> createCommandValidate() {
 }
 
 } // namespace ktx
+
+KTX_COMMAND_ENTRY_POINT(ktxValidate, ktx::CommandValidate)

--- a/tools/ktx/utility.h
+++ b/tools/ktx/utility.h
@@ -5,25 +5,8 @@
 
 #pragma once
 
-#include <string_view>
-
-
 // -------------------------------------------------------------------------------------------------
 
 namespace ktx {
-
-[[nodiscard]] constexpr inline std::string_view trim_front(std::string_view s) noexcept {
-    s.remove_prefix(std::min(s.find_first_not_of(" \t\r\v\n"), s.size()));
-    return s;
-}
-
-[[nodiscard]] constexpr inline std::string_view trim_back(std::string_view s) noexcept {
-    s.remove_suffix(std::min(s.size() - s.find_last_not_of(" \t\r\v\n") - 1, s.size()));
-    return s;
-}
-
-[[nodiscard]] constexpr inline std::string_view trim(std::string_view s) noexcept {
-	return trim_front(trim_back(s));
-}
 
 } // namespace ktx

--- a/utils/argparser.h
+++ b/utils/argparser.h
@@ -51,8 +51,8 @@ class argparser {
     argparser(argvector& argv, unsigned int startindex = 0)
         : optind(startindex), argv(argv) { }
 
-    argparser(int argc, const _TCHAR* const* argv1, unsigned int startindex = 1)
-        : optind(startindex), argv(argc, argv1)  { }
+    argparser(int argc, const _TCHAR* const* argv1)
+        : optind(1), argv(argc, argv1)  { }
 
     int getopt(_tstring* shortopts, const struct option* longopts,
                int* longindex = nullptr);

--- a/utils/ktxapp.h
+++ b/utils/ktxapp.h
@@ -163,8 +163,7 @@ class ktxApp {
     enum OutfilePos { eNone, eFirst, eLast };
     void processCommandLine(int argc, _TCHAR* argv[],
                             StdinUse stdinStat = eAllowStdin,
-                            OutfilePos outfilePos = eNone,
-                            int startIndex = 1)
+                            OutfilePos outfilePos = eNone)
     {
         uint32_t i;
         size_t slash, dot;
@@ -180,7 +179,7 @@ class ktxApp {
             if (dot != _tstring::npos)
                 name.erase(dot, _tstring::npos); // Remove extension.
 
-        argparser parser(argc, argv, startIndex);
+        argparser parser(argc, argv);
         processOptions(parser);
 
         i = parser.optind;


### PR DESCRIPTION
Set up some minimal infrastructure that will enable future development to add support for external plugins through shared libraries or executables, and also add appropriate infrastructure to be able to build individual sub-commands as separate shared libraries or executables.